### PR TITLE
Migrate sample to Media3 ExoPlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ dependencies {
 
 ## Sample Dependencies
 * [glide](https://github.com/bumptech/glide)
-* [ExoPlayer](https://github.com/google/ExoPlayer)
+* [Media3 ExoPlayer](https://developer.android.com/jetpack/androidx/releases/media3)
 
 
 ## License

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -33,6 +33,6 @@ dependencies {
 
     implementation project(':mp4compose')
 
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.19.1'
+    implementation 'androidx.media3:media3-exoplayer:1.3.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 }

--- a/sample/src/main/java/com/daasuu/sample/widget/PlayerTextureView.java
+++ b/sample/src/main/java/com/daasuu/sample/widget/PlayerTextureView.java
@@ -8,15 +8,14 @@ import android.util.Log;
 import android.view.Surface;
 import android.view.TextureView;
 
-import com.google.android.exoplayer2.MediaItem;
-import com.google.android.exoplayer2.Player;
-import com.google.android.exoplayer2.SimpleExoPlayer;
-import com.google.android.exoplayer2.VideoSize;
-import com.google.android.exoplayer2.source.MediaSource;
-import com.google.android.exoplayer2.source.ProgressiveMediaSource;
-import com.google.android.exoplayer2.upstream.DataSource;
-import com.google.android.exoplayer2.upstream.DefaultDataSourceFactory;
-import com.google.android.exoplayer2.util.Util;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.Player;
+import androidx.media3.common.VideoSize;
+import androidx.media3.datasource.DefaultDataSource;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.source.MediaSource;
+import androidx.media3.exoplayer.source.ProgressiveMediaSource;
 
 @SuppressLint("ViewConstructor")
 public class PlayerTextureView extends TextureView implements TextureView.SurfaceTextureListener, Player.Listener {
@@ -24,22 +23,22 @@ public class PlayerTextureView extends TextureView implements TextureView.Surfac
     private final static String TAG = PlayerTextureView.class.getSimpleName();
 
     protected static final float DEFAULT_ASPECT = -1f;
-    private final SimpleExoPlayer player;
+    private final ExoPlayer player;
     protected float videoAspect = DEFAULT_ASPECT;
 
     public PlayerTextureView(Context context, String path) {
         super(context, null, 0);
 
         // Produces DataSource instances through which media data is loaded.
-        DataSource.Factory dataSourceFactory = new DefaultDataSourceFactory(context, Util.getUserAgent(context, "yourApplicationName"));
+        DataSource.Factory dataSourceFactory = new DefaultDataSource.Factory(context);
 
         // This is the MediaSource representing the media to be played.
         MediaItem mediaItem = MediaItem.fromUri(Uri.parse(path));
         MediaSource videoSource = new ProgressiveMediaSource.Factory(dataSourceFactory)
                 .createMediaSource(mediaItem);
 
-        // SimpleExoPlayer
-        player = new SimpleExoPlayer.Builder(context).build();
+        // ExoPlayer
+        player = new ExoPlayer.Builder(context).build();
         player.setRepeatMode(Player.REPEAT_MODE_ALL);
         // Prepare the player with the source.
         player.setMediaSource(videoSource);


### PR DESCRIPTION
## Summary
- replace deprecated ExoPlayer dependency with AndroidX Media3
- update PlayerTextureView to new Media3 packages
- note Media3 ExoPlayer in README

## Testing
- `./gradlew build` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_686a1239674c832cad3008bedef8c877