### PR TITLE
Fix gallery export crash on Android 11+

### DIFF
--- a/sample/src/main/java/com/daasuu/sample/BasicUsageActivity.java
+++ b/sample/src/main/java/com/daasuu/sample/BasicUsageActivity.java
@@ -1,13 +1,12 @@
 package com.daasuu.sample;
 
 import android.app.AlertDialog;
-import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
-import android.provider.MediaStore;
+import android.media.MediaScannerConnection;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.View;
@@ -218,15 +217,13 @@ public class BasicUsageActivity extends AppCompatActivity {
      * @return The video MediaStore URI
      */
     public static void exportMp4ToGallery(Context context, String filePath) {
-        // ビデオのメタデータを作成する
-        final ContentValues values = new ContentValues(2);
-        values.put(MediaStore.Video.Media.MIME_TYPE, "video/mp4");
-        values.put(MediaStore.Video.Media.DATA, filePath);
-        // MediaStoreに登録
-        context.getContentResolver().insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
-                values);
-        context.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE,
-                Uri.parse("file://" + filePath)));
+        // Index the exported file so that it becomes visible in gallery apps.
+        MediaScannerConnection.scanFile(
+                context,
+                new String[]{filePath},
+                new String[]{"video/mp4"},
+                null
+        );
     }
 
 

--- a/sample/src/main/java/com/daasuu/sample/FillModeCustomActivity.java
+++ b/sample/src/main/java/com/daasuu/sample/FillModeCustomActivity.java
@@ -1,7 +1,6 @@
 package com.daasuu.sample;
 
 import android.app.AlertDialog;
-import android.content.ContentValues;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.Point;
@@ -9,7 +8,7 @@ import android.media.MediaMetadataRetriever;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Environment;
-import android.provider.MediaStore;
+import android.media.MediaScannerConnection;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
@@ -277,12 +276,12 @@ public class FillModeCustomActivity extends AppCompatActivity {
     }
 
     public static void exportMp4ToGallery(Context context, String filePath) {
-        final ContentValues values = new ContentValues(2);
-        values.put(MediaStore.Video.Media.MIME_TYPE, "video/mp4");
-        values.put(MediaStore.Video.Media.DATA, filePath);
-        context.getContentResolver().insert(MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
-                values);
-        context.sendBroadcast(new Intent(Intent.ACTION_MEDIA_SCANNER_SCAN_FILE,
-                Uri.parse("file://" + filePath)));
+        // Index the exported file so that it appears in gallery apps.
+        MediaScannerConnection.scanFile(
+                context,
+                new String[]{filePath},
+                new String[]{"video/mp4"},
+                null
+        );
     }
 }


### PR DESCRIPTION
## Summary
- avoid `_data` mutation when exporting to the gallery
- use `MediaScannerConnection.scanFile` so videos appear in gallery apps

## Testing
- `./gradlew test` *(fails: unable to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a755eb1b8832ca2bccb2552da1cb4